### PR TITLE
Fixes reloadDataPacks() on Paper 1.21.4 build 63 and above

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = CommandAPI
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 9.7.0
+PROJECT_NUMBER         = 9.7.1-SNAPSHOT
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/commandapi-annotations/pom.xml
+++ b/commandapi-annotations/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>dev.jorel</groupId>
 		<artifactId>commandapi</artifactId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commandapi-annotations</artifactId>

--- a/commandapi-codecov/pom.xml
+++ b/commandapi-codecov/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>dev.jorel</groupId>
 		<artifactId>commandapi</artifactId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commandapi-codecov</artifactId>

--- a/commandapi-core/pom.xml
+++ b/commandapi-core/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<artifactId>commandapi</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/commandapi-documentation-code/pom.xml
+++ b/commandapi-documentation-code/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>commandapi</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commandapi-documentation-code</artifactId>

--- a/commandapi-documentation-velocity-code/pom.xml
+++ b/commandapi-documentation-velocity-code/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.jorel</groupId>
 		<artifactId>commandapi</artifactId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commandapi-documentation-velocity-code</artifactId>

--- a/commandapi-kotlin/commandapi-bukkit-kotlin/pom.xml
+++ b/commandapi-kotlin/commandapi-bukkit-kotlin/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>dev.jorel</groupId>
 		<artifactId>commandapi-kotlin</artifactId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commandapi-bukkit-kotlin</artifactId>

--- a/commandapi-kotlin/commandapi-core-kotlin/pom.xml
+++ b/commandapi-kotlin/commandapi-core-kotlin/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>dev.jorel</groupId>
 		<artifactId>commandapi-kotlin</artifactId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commandapi-core-kotlin</artifactId>

--- a/commandapi-kotlin/commandapi-velocity-kotlin/pom.xml
+++ b/commandapi-kotlin/commandapi-velocity-kotlin/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>dev.jorel</groupId>
 		<artifactId>commandapi-kotlin</artifactId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commandapi-velocity-kotlin</artifactId>

--- a/commandapi-kotlin/pom.xml
+++ b/commandapi-kotlin/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.jorel</groupId>
 		<artifactId>commandapi</artifactId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commandapi-kotlin</artifactId>

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>commandapi-bukkit-core</artifactId>
 	<repositories>

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-mojang-mapped/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-mojang-mapped/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.5/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.16.5/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-nms</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.17-common/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.17-common/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-nms</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.17.1/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.17.1/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-nms</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.17/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.17/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-nms</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18.2/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18.2/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-nms</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.18/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-nms</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19-common/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19-common/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-nms</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.1/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.1/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-nms</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.3/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.3/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-nms</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.4/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19.4/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-nms</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.19/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-nms</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.2/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.2/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-nms</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.3/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.3/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-nms</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.5/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.5/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-nms</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-nms</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21.2/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21.2/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-nms</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21.4/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21.4/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-nms</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_21_R3.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_21_R3.java
@@ -28,8 +28,6 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-nms</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-nms-common/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-nms-common/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-nms</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-nms-dependency-mojang-mapped/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-nms-dependency-mojang-mapped/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-nms</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-nms-dependency/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-nms-dependency/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-nms</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commandapi-bukkit-nms</artifactId>

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin-common/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin-common/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>dev.jorel</groupId>
 		<artifactId>commandapi-bukkit</artifactId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commandapi-bukkit-plugin-common</artifactId>

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin-mojang-mapped/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin-mojang-mapped/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-shade-mojang-mapped/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-shade-mojang-mapped/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-shade/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-shade/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test-toolkit/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test-toolkit/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>dev.jorel</groupId>
 		<artifactId>commandapi-bukkit</artifactId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commandapi-bukkit-test-toolkit</artifactId>

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-kotlin-test/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-kotlin-test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-test</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.16.5/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.16.5/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-test</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.17/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.17/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-test</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.18/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.18/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-test</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.2/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.2/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-test</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.4/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.19.4/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-test</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20.2/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20.2/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-test</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20.3/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20.3/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-test</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20.5/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20.5/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-test</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl-1.20/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-test</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-impl/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-test</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/commandapi-bukkit-test-tests/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit-test</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-test/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>commandapi-bukkit-test</artifactId>
 	<packaging>pom</packaging>

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-vh/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-vh/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<artifactId>commandapi-bukkit</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/commandapi-platforms/commandapi-bukkit/pom.xml
+++ b/commandapi-platforms/commandapi-bukkit/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>commandapi-platforms</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commandapi-bukkit</artifactId>

--- a/commandapi-platforms/commandapi-sponge/commandapi-sponge-core/pom.xml
+++ b/commandapi-platforms/commandapi-sponge/commandapi-sponge-core/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>commandapi-sponge</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commandapi-sponge-core</artifactId>

--- a/commandapi-platforms/commandapi-sponge/commandapi-sponge-plugin-test/pom.xml
+++ b/commandapi-platforms/commandapi-sponge/commandapi-sponge-plugin-test/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>commandapi-sponge</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commandapi-sponge-plugin-test</artifactId>

--- a/commandapi-platforms/commandapi-sponge/commandapi-sponge-plugin/pom.xml
+++ b/commandapi-platforms/commandapi-sponge/commandapi-sponge-plugin/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>commandapi-sponge</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commandapi-sponge-plugin</artifactId>

--- a/commandapi-platforms/commandapi-sponge/commandapi-sponge-shade/pom.xml
+++ b/commandapi-platforms/commandapi-sponge/commandapi-sponge-shade/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>commandapi-sponge</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commandapi-sponge-shade</artifactId>

--- a/commandapi-platforms/commandapi-sponge/pom.xml
+++ b/commandapi-platforms/commandapi-sponge/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>commandapi-platforms</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commandapi-sponge</artifactId>

--- a/commandapi-platforms/commandapi-velocity/commandapi-velocity-core/pom.xml
+++ b/commandapi-platforms/commandapi-velocity/commandapi-velocity-core/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>commandapi-velocity</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commandapi-velocity-core</artifactId>

--- a/commandapi-platforms/commandapi-velocity/commandapi-velocity-plugin-test/pom.xml
+++ b/commandapi-platforms/commandapi-velocity/commandapi-velocity-plugin-test/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>commandapi-velocity</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commandapi-velocity-plugin-test</artifactId>

--- a/commandapi-platforms/commandapi-velocity/commandapi-velocity-plugin/pom.xml
+++ b/commandapi-platforms/commandapi-velocity/commandapi-velocity-plugin/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>commandapi-velocity</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commandapi-velocity-plugin</artifactId>

--- a/commandapi-platforms/commandapi-velocity/commandapi-velocity-shade/pom.xml
+++ b/commandapi-platforms/commandapi-velocity/commandapi-velocity-shade/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>commandapi-velocity</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commandapi-velocity-shade</artifactId>

--- a/commandapi-platforms/commandapi-velocity/pom.xml
+++ b/commandapi-platforms/commandapi-velocity/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>commandapi-platforms</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commandapi-velocity</artifactId>

--- a/commandapi-platforms/pom.xml
+++ b/commandapi-platforms/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>commandapi</artifactId>
 		<groupId>dev.jorel</groupId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commandapi-platforms</artifactId>

--- a/commandapi-plugin/pom.xml
+++ b/commandapi-plugin/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>dev.jorel</groupId>
 		<artifactId>commandapi</artifactId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>commandapi-plugin</artifactId>

--- a/commandapi-preprocessor/pom.xml
+++ b/commandapi-preprocessor/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>dev.jorel</groupId>
 		<artifactId>commandapi</artifactId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/docs/latest.html
+++ b/docs/latest.html
@@ -1,7 +1,7 @@
 <html>
 
 <head>
-    <meta http-equiv="refresh" content="0; URL='./9.7.0/index.html" />
+    <meta http-equiv="refresh" content="0; URL='./9.7.1-SNAPSHOT/index.html" />
     <style>
         body {
             margin: 0;
@@ -47,7 +47,7 @@
 <body>
     <div id="sidebar"></div>
     <div id="main">
-        <p>Loading the CommandAPI documentation...<br><span>(Didn't load? Try <a href="./9.7.0/index.html">this link here!</a>)</span></p>
+        <p>Loading the CommandAPI documentation...<br><span>(Didn't load? Try <a href="./9.7.1-SNAPSHOT/index.html">this link here!</a>)</span></p>
     </div>
 </body>
 

--- a/docssrc/book.toml
+++ b/docssrc/book.toml
@@ -2,10 +2,10 @@
 authors = ["JorelAli"]
 multilingual = false
 src = "src"
-title = "CommandAPI Documentation v9.7.0"
+title = "CommandAPI Documentation v9.7.1-SNAPSHOT"
 
 [build]
-build-dir = "./../docs/9.7.0"
+build-dir = "./../docs/9.7.1-SNAPSHOT"
 create-missing = false
 
 [output.html]

--- a/docssrc/src/kotlinintro.md
+++ b/docssrc/src/kotlinintro.md
@@ -17,7 +17,7 @@ To install the DSL, you need to add the `commandapi-bukkit-kotlin` dependency in
     <dependency>
         <groupId>dev.jorel</groupId>
         <artifactId>commandapi-bukkit-kotlin</artifactId>
-        <version>9.7.0</version>
+        <version>9.7.1-SNAPSHOT</version>
     </dependency>
 </dependencies>
 ```
@@ -93,13 +93,13 @@ Next, you need to add the dependency:
 
 ```groovy,build.gradle
 dependencies {
-    implementation "dev.jorel:commandapi-bukkit-kotlin:9.7.0"
+    implementation "dev.jorel:commandapi-bukkit-kotlin:9.7.1-SNAPSHOT"
 }
 ```
 
 ```kotlin,build.gradle.kts
 dependencies {
-    implementation("dev.jorel:commandapi-bukkit-kotlin:9.7.0")
+    implementation("dev.jorel:commandapi-bukkit-kotlin:9.7.1-SNAPSHOT")
 }
 ```
 

--- a/docssrc/src/setup_annotations.md
+++ b/docssrc/src/setup_annotations.md
@@ -15,7 +15,7 @@ The annotation system effectively needs to be added twice: Once for compilation 
       <dependency>
           <groupId>dev.jorel</groupId>
           <artifactId>commandapi-annotations</artifactId>
-          <version>9.7.0</version>
+          <version>9.7.1-SNAPSHOT</version>
           <scope>provided</scope>
       </dependency>
   </dependencies>
@@ -35,7 +35,7 @@ The annotation system effectively needs to be added twice: Once for compilation 
                       <path>
                           <groupId>dev.jorel</groupId>
                           <artifactId>commandapi-annotations</artifactId>
-                          <version>9.7.0</version>
+                          <version>9.7.1-SNAPSHOT</version>
                       </path>
                   </annotationProcessorPaths>
               </configuration>
@@ -74,15 +74,15 @@ The annotation system effectively needs to be added twice: Once for compilation 
   
   ```groovy,build.gradle
   dependencies {
-      compileOnly "dev.jorel:commandapi-annotations:9.7.0"
-      annotationProcessor "dev.jorel:commandapi-annotations:9.7.0"
+      compileOnly "dev.jorel:commandapi-annotations:9.7.1-SNAPSHOT"
+      annotationProcessor "dev.jorel:commandapi-annotations:9.7.1-SNAPSHOT"
   }
   ```
   
   ```kotlin,build.gradle.kts
   dependencies {
-      compileOnly("dev.jorel:commandapi-annotations:9.7.0")
-      annotationProcessor("dev.jorel:commandapi-annotations:9.7.0")
+      compileOnly("dev.jorel:commandapi-annotations:9.7.1-SNAPSHOT")
+      annotationProcessor("dev.jorel:commandapi-annotations:9.7.1-SNAPSHOT")
   }
   ```
   

--- a/docssrc/src/setup_dev.md
+++ b/docssrc/src/setup_dev.md
@@ -40,7 +40,7 @@ dependencies:
       <dependency>
           <groupId>dev.jorel</groupId>
           <artifactId>commandapi-bukkit-core</artifactId>
-          <version>9.7.0</version>
+          <version>9.7.1-SNAPSHOT</version>
           <scope>provided</scope>
       </dependency>
   </dependencies>
@@ -61,7 +61,7 @@ dependencies:
 
   ```gradle
   dependencies {
-      compileOnly "dev.jorel:commandapi-bukkit-core:9.7.0"
+      compileOnly "dev.jorel:commandapi-bukkit-core:9.7.1-SNAPSHOT"
   }
   ```
 

--- a/docssrc/src/setup_shading.md
+++ b/docssrc/src/setup_shading.md
@@ -122,7 +122,7 @@ Add the CommandAPI shade dependency:
     <dependency>
         <groupId>dev.jorel</groupId>
         <artifactId>commandapi-bukkit-shade</artifactId>
-        <version>9.7.0</version>
+        <version>9.7.1-SNAPSHOT</version>
     </dependency>
 </dependencies>
 ```
@@ -132,7 +132,7 @@ Add the CommandAPI shade dependency:
     <dependency>
         <groupId>dev.jorel</groupId>
         <artifactId>commandapi-bukkit-shade-mojang-mapped</artifactId>
-        <version>9.7.0</version>
+        <version>9.7.1-SNAPSHOT</version>
     </dependency>
 </dependencies>
 ```
@@ -228,25 +228,25 @@ Next, we declare our dependencies:
 
 ```groovy,build.gradle_(Spigot_Mappings)
 dependencies {
-    implementation "dev.jorel:commandapi-bukkit-shade:9.7.0"
+    implementation "dev.jorel:commandapi-bukkit-shade:9.7.1-SNAPSHOT"
 }
 ```
 
 ```groovy,build.gradle_(Mojang_Mappings)
 dependencies {
-    implementation "dev.jorel:commandapi-bukkit-shade-mojang-mapped:9.7.0"
+    implementation "dev.jorel:commandapi-bukkit-shade-mojang-mapped:9.7.1-SNAPSHOT"
 }
 ```
 
 ```kotlin,build.gradle.kts_(Spigot_Mappings)
 dependencies {
-    implementation("dev.jorel:commandapi-bukkit-shade:9.7.0")
+    implementation("dev.jorel:commandapi-bukkit-shade:9.7.1-SNAPSHOT")
 }
 ```
 
 ```kotlin,build.gradle.kts_(Mojang_Mappings)
 dependencies {
-    implementation("dev.jorel:commandapi-bukkit-shade-mojang-mapped:9.7.0")
+    implementation("dev.jorel:commandapi-bukkit-shade-mojang-mapped:9.7.1-SNAPSHOT")
 }
 ```
 

--- a/docssrc/src/test_setup.md
+++ b/docssrc/src/test_setup.md
@@ -21,7 +21,7 @@ When you add the dependencies for MockBukkit and `commandapi-bukkit-test-toolkit
     <dependency>
         <groupId>dev.jorel</groupId>
         <artifactId>commandapi-bukkit-test-toolkit</artifactId>
-        <version>9.7.0</version>
+        <version>9.7.1-SNAPSHOT</version>
         <scope>test</scope>
     </dependency>
 
@@ -29,7 +29,7 @@ When you add the dependencies for MockBukkit and `commandapi-bukkit-test-toolkit
     <dependency>
         <groupId>dev.jorel</groupId>
         <artifactId>commandapi-bukkit-core</artifactId>
-        <version>9.7.0</version>
+        <version>9.7.1-SNAPSHOT</version>
         <scope>provided</scope>
     </dependency>
 
@@ -59,7 +59,7 @@ dependencies {
     testImplementation 'dev.jorel.commandapi-bukkit-test-toolkit:9.6.2-SNAPSHOT'
 
     // May be the shade dependency and/or mojang-mapped
-    compileOnly 'dev.jorel:commandapi-bukkit-core:9.7.0'
+    compileOnly 'dev.jorel:commandapi-bukkit-core:9.7.1-SNAPSHOT'
 
     // Can also be paper-api
     compileOnly 'org.spigotmc:spigot-api:1.21.1-R0.1-SNAPSHOT'
@@ -77,7 +77,7 @@ dependencies {
     testImplementation('dev.jorel.commandapi-bukkit-test-toolkit:9.6.2-SNAPSHOT')
 
     // May be the shade dependency and/or mojang-mapped
-    compileOnly('dev.jorel:commandapi-bukkit-core:9.7.0')
+    compileOnly('dev.jorel:commandapi-bukkit-core:9.7.1-SNAPSHOT')
 
     // Can also be paper-api
     compileOnly('org.spigotmc:spigot-api:1.21.1-R0.1-SNAPSHOT')

--- a/examples/bukkit/automated-tests-shaded/README.md
+++ b/examples/bukkit/automated-tests-shaded/README.md
@@ -18,14 +18,14 @@ Key points:
 	<dependency>
 		<groupId>dev.jorel</groupId>
 		<artifactId>commandapi-bukkit-test-toolkit</artifactId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 		<scope>test</scope>
 	</dependency>
 
 	<dependency>
 		<groupId>dev.jorel</groupId>
 		<artifactId>commandapi-bukkit-shade</artifactId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 		<scope>compile</scope>
 	</dependency>
 

--- a/examples/bukkit/automated-tests-shaded/pom.xml
+++ b/examples/bukkit/automated-tests-shaded/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>dev.jorel</groupId>
 			<artifactId>commandapi-bukkit-test-toolkit</artifactId>
-			<version>9.7.0</version>
+			<version>9.7.1-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>dev.jorel</groupId>
 			<artifactId>commandapi-bukkit-shade</artifactId>
-			<version>9.7.0</version>
+			<version>9.7.1-SNAPSHOT</version>
 			<scope>compile</scope>
 		</dependency>
 

--- a/examples/bukkit/automated-tests/README.md
+++ b/examples/bukkit/automated-tests/README.md
@@ -18,14 +18,14 @@ Key points:
 	<dependency>
 		<groupId>dev.jorel</groupId>
 		<artifactId>commandapi-bukkit-test-toolkit</artifactId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 		<scope>test</scope>
 	</dependency>
 
 	<dependency>
 		<groupId>dev.jorel</groupId>
 		<artifactId>commandapi-bukkit-core</artifactId>
-		<version>9.7.0</version>
+		<version>9.7.1-SNAPSHOT</version>
 		<scope>provided</scope>
 	</dependency>
 

--- a/examples/bukkit/automated-tests/pom.xml
+++ b/examples/bukkit/automated-tests/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>dev.jorel</groupId>
 			<artifactId>commandapi-bukkit-test-toolkit</artifactId>
-			<version>9.7.0</version>
+			<version>9.7.1-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>dev.jorel</groupId>
 			<artifactId>commandapi-bukkit-core</artifactId>
-			<version>9.7.0</version>
+			<version>9.7.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/examples/bukkit/commandtrees/pom.xml
+++ b/examples/bukkit/commandtrees/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>dev.jorel</groupId>
 			<artifactId>commandapi-bukkit-core</artifactId>
-			<version>9.7.0</version>
+			<version>9.7.1-SNAPSHOT</version>
 		</dependency>
 
 		<!--This adds the Spigot API artifact to the build -->

--- a/examples/bukkit/gradle-groovy/README.md
+++ b/examples/bukkit/gradle-groovy/README.md
@@ -7,7 +7,7 @@ Key points:
 - The `commandapi-bukkit-plugin` dependency is used:
 
   ```groovy
-  implementation 'dev.jorel:commandapi-bukkit-plugin:9.7.0'
+  implementation 'dev.jorel:commandapi-bukkit-plugin:9.7.1-SNAPSHOT'
   ```
 
 - In the plugin.yml, CommandAPI is listed as a depend:

--- a/examples/bukkit/gradle-groovy/build.gradle
+++ b/examples/bukkit/gradle-groovy/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 	implementation 'org.spigotmc:spigot-api:1.19.4-R0.1-SNAPSHOT'
 
 	// The CommandAPI dependency used for Bukkit and it's forks
-	implementation 'dev.jorel:commandapi-bukkit-plugin:9.7.0'
+	implementation 'dev.jorel:commandapi-bukkit-plugin:9.7.1-SNAPSHOT'
 	
 	// NBT API to use NBT-based arguments
 	implementation 'de.tr7zw:item-nbt-api-plugin:2.12.2'

--- a/examples/bukkit/gradle-kotlin/README.md
+++ b/examples/bukkit/gradle-kotlin/README.md
@@ -7,7 +7,7 @@ Key points:
 - The `commandapi-bukkit-plugin` dependency is used:
 
   ```kotlin
-  implementation("dev.jorel:commandapi-bukkit-plugin:9.7.0")
+  implementation("dev.jorel:commandapi-bukkit-plugin:9.7.1-SNAPSHOT")
   ```
 
 - In the plugin.yml, CommandAPI is listed as a depend:

--- a/examples/bukkit/gradle-kotlin/build.gradle.kts
+++ b/examples/bukkit/gradle-kotlin/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
 	implementation("org.spigotmc:spigot-api:1.19.4-R0.1-SNAPSHOT")
 
 	// The CommandAPI dependency used for Bukkit and it's forks
-	implementation("dev.jorel:commandapi-bukkit-plugin:9.7.0")
+	implementation("dev.jorel:commandapi-bukkit-plugin:9.7.1-SNAPSHOT")
 
 	// NBT API to use NBT-based arguments
 	implementation("de.tr7zw:item-nbt-api-plugin:2.12.2")

--- a/examples/bukkit/kotlindsl-gradle/README.md
+++ b/examples/bukkit/kotlindsl-gradle/README.md
@@ -9,7 +9,7 @@ Key points:
 - Add the `commandapi-kotlin-bukkit` dependency to your project:
 
   ```kotlin
-  compileOnly("dev.jorel:commandapi-bukkit-kotlin:9.7.0")
+  compileOnly("dev.jorel:commandapi-bukkit-kotlin:9.7.1-SNAPSHOT")
   ```
 
 - The Kotlin DSL must not be shaded into your plugin

--- a/examples/bukkit/kotlindsl-gradle/build.gradle.kts
+++ b/examples/bukkit/kotlindsl-gradle/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
 	implementation("org.spigotmc:spigot-api:1.19.4-R0.1-SNAPSHOT")
 
 	// The CommandAPI dependency used for Bukkit and it's forks
-	implementation("dev.jorel:commandapi-bukkit-core:9.7.0")
+	implementation("dev.jorel:commandapi-bukkit-core:9.7.1-SNAPSHOT")
 	// Due to all functions available in the kotlindsl being inlined, we only need this dependency at compile-time
-	compileOnly("dev.jorel:commandapi-bukkit-kotlin:9.7.0")
+	compileOnly("dev.jorel:commandapi-bukkit-kotlin:9.7.1-SNAPSHOT")
 }

--- a/examples/bukkit/kotlindsl/README.md
+++ b/examples/bukkit/kotlindsl/README.md
@@ -12,7 +12,7 @@ Key points:
   <dependency>
     <groupId>dev.jorel</groupId>
     <artifactId>commandapi-kotlin-bukkit</artifactId>
-    <version>9.7.0</version>
+    <version>9.7.1-SNAPSHOT</version>
   </dependency>
   ```
 

--- a/examples/bukkit/kotlindsl/pom.xml
+++ b/examples/bukkit/kotlindsl/pom.xml
@@ -21,13 +21,13 @@
 		<dependency>
 			<groupId>dev.jorel</groupId>
 			<artifactId>commandapi-bukkit-core</artifactId>
-			<version>9.7.0</version>
+			<version>9.7.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>dev.jorel</groupId>
 			<artifactId>commandapi-bukkit-kotlin</artifactId>
-			<version>9.7.0</version>
+			<version>9.7.1-SNAPSHOT</version>
 		</dependency>
 
 		<!--This adds the Spigot API artifact to the build -->

--- a/examples/bukkit/maven-annotations/README.md
+++ b/examples/bukkit/maven-annotations/README.md
@@ -11,13 +11,13 @@ Key points:
       <dependency>
           <groupId>dev.jorel</groupId>
           <artifactId>commandapi-bukkit-plugin</artifactId>
-          <version>9.7.0</version>
+          <version>9.7.1-SNAPSHOT</version>
           <scope>provided</scope>
       </dependency>
       <dependency>
           <groupId>dev.jorel</groupId>
           <artifactId>commandapi-annotations</artifactId>
-          <version>9.7.0</version>
+          <version>9.7.1-SNAPSHOT</version>
           <scope>provided</scope>
       </dependency>
   </dependencies>
@@ -37,7 +37,7 @@ Key points:
                       <path>
                           <groupId>dev.jorel</groupId>
                           <artifactId>commandapi-annotations</artifactId>
-                          <version>9.7.0</version>
+                          <version>9.7.1-SNAPSHOT</version>
                       </path>
                   </annotationProcessorPaths>
               </configuration>

--- a/examples/bukkit/maven-annotations/pom.xml
+++ b/examples/bukkit/maven-annotations/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>dev.jorel</groupId>
 			<artifactId>commandapi-bukkit-plugin</artifactId>
-			<version>9.7.0</version>
+			<version>9.7.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -36,7 +36,7 @@
 		<dependency>
 			<groupId>dev.jorel</groupId>
 			<artifactId>commandapi-annotations</artifactId>
-			<version>9.7.0</version>
+			<version>9.7.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -69,7 +69,7 @@
 						<path>
 							<groupId>dev.jorel</groupId>
 							<artifactId>commandapi-annotations</artifactId>
-							<version>9.7.0</version>
+							<version>9.7.1-SNAPSHOT</version>
 						</path>
 					</annotationProcessorPaths>
 					<release>16</release>

--- a/examples/bukkit/maven-shaded-annotations/README.md
+++ b/examples/bukkit/maven-shaded-annotations/README.md
@@ -11,12 +11,12 @@ Key points:
       <dependency>
           <groupId>dev.jorel</groupId>
           <artifactId>commandapi-bukkit-shade</artifactId>
-          <version>9.7.0</version>
+          <version>9.7.1-SNAPSHOT</version>
       </dependency>
       <dependency>
           <groupId>dev.jorel</groupId>
           <artifactId>commandapi-annotations</artifactId>
-          <version>9.7.0</version>
+          <version>9.7.1-SNAPSHOT</version>
           <scope>provided</scope>
       </dependency>
   </dependencies>
@@ -36,7 +36,7 @@ Key points:
                       <path>
                           <groupId>dev.jorel</groupId>
                           <artifactId>commandapi-annotations</artifactId>
-                          <version>9.7.0</version>
+                          <version>9.7.1-SNAPSHOT</version>
                       </path>
                   </annotationProcessorPaths>
               </configuration>

--- a/examples/bukkit/maven-shaded-annotations/pom.xml
+++ b/examples/bukkit/maven-shaded-annotations/pom.xml
@@ -28,14 +28,14 @@
 		<dependency>
 			<groupId>dev.jorel</groupId>
 			<artifactId>commandapi-bukkit-shade</artifactId>
-			<version>9.7.0</version>
+			<version>9.7.1-SNAPSHOT</version>
 		</dependency>
 
 		<!-- The CommandAPI dependency used for building commands with annotations -->
 		<dependency>
 			<groupId>dev.jorel</groupId>
 			<artifactId>commandapi-annotations</artifactId>
-			<version>9.7.0</version>
+			<version>9.7.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -62,7 +62,7 @@
 						<path>
 							<groupId>dev.jorel</groupId>
 							<artifactId>commandapi-annotations</artifactId>
-							<version>9.7.0</version>
+							<version>9.7.1-SNAPSHOT</version>
 						</path>
 					</annotationProcessorPaths>
 					<release>17</release>

--- a/examples/bukkit/maven-shaded-tests/pom.xml
+++ b/examples/bukkit/maven-shaded-tests/pom.xml
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>dev.jorel</groupId>
 			<artifactId>commandapi-bukkit-test-tests</artifactId>
-			<version>9.7.0</version>
+			<version>9.7.1-SNAPSHOT</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>dev.jorel</groupId>
 			<artifactId>commandapi-bukkit-shade</artifactId>
-			<version>9.7.0</version>
+			<version>9.7.1-SNAPSHOT</version>
 		</dependency>
 
 		<!--This adds the Spigot API artifact to the build -->
@@ -69,14 +69,14 @@
 			<!-- Generic test implementation -->
 			<groupId>dev.jorel</groupId>
 			<artifactId>commandapi-bukkit-test-impl</artifactId>
-			<version>9.7.0</version>
+			<version>9.7.1-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<!-- Test implementation specific to 1.19.2 -->
 			<groupId>dev.jorel</groupId>
 			<artifactId>commandapi-bukkit-test-impl-1.19.2</artifactId>
-			<version>9.7.0</version>
+			<version>9.7.1-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/examples/bukkit/maven-shaded/README.md
+++ b/examples/bukkit/maven-shaded/README.md
@@ -10,7 +10,7 @@ Key points:
   <dependency>
       <groupId>dev.jorel</groupId>
       <artifactId>commandapi-bukkit-shade</artifactId>
-      <version>9.7.0</version>
+      <version>9.7.1-SNAPSHOT</version>
   </dependency>
   ```
 

--- a/examples/bukkit/maven-shaded/pom.xml
+++ b/examples/bukkit/maven-shaded/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>dev.jorel</groupId>
 			<artifactId>commandapi-bukkit-shade</artifactId>
-			<version>9.7.0</version>
+			<version>9.7.1-SNAPSHOT</version>
 		</dependency>
 
 		<!--This adds the Spigot API artifact to the build -->

--- a/examples/bukkit/maven/README.md
+++ b/examples/bukkit/maven/README.md
@@ -10,7 +10,7 @@ Key points:
   <dependency>
       <groupId>dev.jorel</groupId>
       <artifactId>commandapi-bukkit-plugin</artifactId>
-      <version>9.7.0</version>
+      <version>9.7.1-SNAPSHOT</version>
       <scope>provided</scope>
   </dependency>
   ```

--- a/examples/bukkit/maven/pom.xml
+++ b/examples/bukkit/maven/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>dev.jorel</groupId>
 			<artifactId>commandapi-bukkit-plugin</artifactId>
-			<version>9.7.0</version>
+			<version>9.7.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/examples/velocity/gradle-groovy/README.md
+++ b/examples/velocity/gradle-groovy/README.md
@@ -7,7 +7,7 @@ Key points:
 - The `commandapi-velocity-core` dependency is used
 
   ```groovy
-  implementation 'dev.jorel:commandapi-velocity-core:9.7.0'
+  implementation 'dev.jorel:commandapi-velocity-core:9.7.1-SNAPSHOT'
   ```
 
 - In the `@Plugin` annotation, `commandapi` is listed as a dependency:

--- a/examples/velocity/gradle-groovy/build.gradle
+++ b/examples/velocity/gradle-groovy/build.gradle
@@ -25,5 +25,5 @@ dependencies {
 	implementation 'com.velocitypowered:velocity-api:3.1.1'
 
 	// The CommandAPI dependency used for Velocity
-	implementation 'dev.jorel:commandapi-velocity-core:9.7.0'
+	implementation 'dev.jorel:commandapi-velocity-core:9.7.1-SNAPSHOT'
 }

--- a/examples/velocity/gradle-kotlin/README.md
+++ b/examples/velocity/gradle-kotlin/README.md
@@ -7,7 +7,7 @@ Key points:
 - The `commandapi-velocity-core` dependency is used:
 
   ```kotlin
-  implementation("dev.jorel:commandapi-velocity-core:9.7.0")
+  implementation("dev.jorel:commandapi-velocity-core:9.7.1-SNAPSHOT")
   ```
 
 - In the `@Plugin` annotation, `commandapi` is listed as a dependency:

--- a/examples/velocity/gradle-kotlin/build.gradle.kts
+++ b/examples/velocity/gradle-kotlin/build.gradle.kts
@@ -23,5 +23,5 @@ dependencies {
 	implementation("com.velocitypowered:velocity-api:3.1.1")
 
 	// The CommandAPI dependency used for Velocity
-	implementation("dev.jorel:commandapi-velocity-core:9.7.0")
+	implementation("dev.jorel:commandapi-velocity-core:9.7.1-SNAPSHOT")
 }

--- a/examples/velocity/maven-shaded/README.md
+++ b/examples/velocity/maven-shaded/README.md
@@ -10,7 +10,7 @@ Key points:
   <dependency>
       <groupId>dev.jorel</groupId>
       <artifactId>commandapi-velocity-shade</artifactId>
-      <version>9.7.0</version>
+      <version>9.7.1-SNAPSHOT</version>
   </dependency>
   ```
 

--- a/examples/velocity/maven-shaded/pom.xml
+++ b/examples/velocity/maven-shaded/pom.xml
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>dev.jorel</groupId>
 			<artifactId>commandapi-velocity-shade</artifactId>
-			<version>9.7.0</version>
+			<version>9.7.1-SNAPSHOT</version>
 		</dependency>
 
 		<!-- This adds the Velocity API artifact to the build -->

--- a/examples/velocity/maven/README.md
+++ b/examples/velocity/maven/README.md
@@ -10,7 +10,7 @@ Key points:
   <dependency>
       <groupId>dev.jorel</groupId>
       <artifactId>commandapi-velocity-core</artifactId>
-      <version>9.7.0</version>
+      <version>9.7.1-SNAPSHOT</version>
       <scope>provided</scope>
   </dependency>
   ```

--- a/examples/velocity/maven/pom.xml
+++ b/examples/velocity/maven/pom.xml
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>dev.jorel</groupId>
 			<artifactId>commandapi-velocity-core</artifactId>
-			<version>9.7.0</version>
+			<version>9.7.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
 	<groupId>dev.jorel</groupId>
 	<artifactId>commandapi</artifactId>
-	<version>9.7.0</version>
+	<version>9.7.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>commandapi</name>


### PR DESCRIPTION
Pointed out by @booky10 in Discord, due to the addition of the datapack lifecycle event in this commit (https://github.com/PaperMC/Paper/commit/feb8756567a3db1afcbbac465c8c6623ecfad1ea), `PackRepository#setSelected` now takes in an additional boolean. This results in a `NoSuchMethodException` when trying to run the current code.
This PR aims to fix that.
Also updates the current version to 9.7.1-SNAPSHOT in case we'd want to release this as a bug fix.