### PR TITLE
Register commands as plugin commands on Paper 1.20.6 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,9 +422,6 @@ This is the current roadmap for the CommandAPI (as of 30th April 2024):
                 <b>Bug Fixes:</b>
                 <ul>
                     <li>https://github.com/CommandAPI/CommandAPI/issues/578, https://github.com/CommandAPI/CommandAPI/issues/583, https://github.com/CommandAPI/CommandAPI/pull/629 Fixes <code>Bukkit#dispatchCommand()</code> not working after Paper's Brigadier API changes</li>
-                    <ul>
-                        <li>This also comes with a change to the <code>withUsage()</code> method which starting with this release does have no effect on servers with Paper's Brigadier API</li>
-                    </ul>
                     <li>Fixes <code>PotionEffectArgument.NamespacedKey</code> not having suggestions in some versions</li>
                 </ul>
             </td>

--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ This is the current roadmap for the CommandAPI (as of 30th April 2024):
                 </ul>
                 <b>Bug Fixes:</b>
                 <ul>
+                    <li>https://github.com/CommandAPI/CommandAPI/issues/578, https://github.com/CommandAPI/CommandAPI/issues/583, https://github.com/CommandAPI/CommandAPI/pull/629 Fixes <code>Bukkit#dispatchCommand() not working after Paper's Brigadier API changes</code></li>
                     <li>Fixes <code>PotionEffectArgument.NamespacedKey</code> not having suggestions in some versions</li>
                 </ul>
             </td>

--- a/README.md
+++ b/README.md
@@ -421,7 +421,10 @@ This is the current roadmap for the CommandAPI (as of 30th April 2024):
                 </ul>
                 <b>Bug Fixes:</b>
                 <ul>
-                    <li>https://github.com/CommandAPI/CommandAPI/issues/578, https://github.com/CommandAPI/CommandAPI/issues/583, https://github.com/CommandAPI/CommandAPI/pull/629 Fixes <code>Bukkit#dispatchCommand() not working after Paper's Brigadier API changes</code></li>
+                    <li>https://github.com/CommandAPI/CommandAPI/issues/578, https://github.com/CommandAPI/CommandAPI/issues/583, https://github.com/CommandAPI/CommandAPI/pull/629 Fixes <code>Bukkit#dispatchCommand()</code> not working after Paper's Brigadier API changes</li>
+                    <ul>
+                        <li>This also comes with a change to the <code>withUsage()</code> method which starting with this release does have no effect on servers with Paper's Brigadier API</li>
+                    </ul>
                     <li>Fixes <code>PotionEffectArgument.NamespacedKey</code> not having suggestions in some versions</li>
                 </ul>
             </td>

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/ExecutableCommand.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/ExecutableCommand.java
@@ -190,6 +190,7 @@ extends ExecutableCommand<Impl, CommandSender>
 	/**
 	 * Sets the full usage for this command. This is the usage which is
 	 * shown in the specific /help page for this command (e.g. /help mycommand).
+	 * @apiNote This method has no effect on Paper servers that have Paper's Brigadier API
 	 * @param usage the full usage for this command
 	 * @return this command builder
 	 */

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/ExecutableCommand.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/ExecutableCommand.java
@@ -190,7 +190,6 @@ extends ExecutableCommand<Impl, CommandSender>
 	/**
 	 * Sets the full usage for this command. This is the usage which is
 	 * shown in the specific /help page for this command (e.g. /help mycommand).
-	 * @apiNote This method has no effect on Paper servers that have Paper's Brigadier API
 	 * @param usage the full usage for this command
 	 * @return this command builder
 	 */

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/RegisteredCommand.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/RegisteredCommand.java
@@ -70,6 +70,11 @@ public record RegisteredCommand(
 	 * @return The namespace for this command
 	 */
 	String namespace) {
+
+	public boolean shouldGenerateHelpTopic() {
+		return fullDescription.isPresent() || usageDescription.isPresent() || helpTopic.isPresent();
+	}
+
 	// As https://stackoverflow.com/a/32083420 mentions, Optional's hashCode, equals, and toString method don't work if the
 	//  Optional wraps an array, like `Optional<String[]> usageDescription`, so we have to use the Arrays methods ourselves
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
@@ -277,14 +277,10 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 
 	void updateHelpForCommands(List<RegisteredCommand> commands) {
 		Map<String, HelpTopic> helpTopicsToAdd = new HashMap<>();
-		Set<String> namespacedCommandNames = new HashSet<>();
 
 		for (RegisteredCommand command : commands) {
 			// Don't override the plugin help topic
 			String commandPrefix = generateCommandHelpPrefix(command.commandName());
-
-			// Namespaced commands shouldn't have a help topic, we should save the namespaced command name
-			namespacedCommandNames.add(generateCommandHelpPrefix(command.commandName(), command.namespace()));
 			
 			StringBuilder aliasSb = new StringBuilder();
 			final String shortDescription;
@@ -347,9 +343,6 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 					// Don't override the plugin help topic
 					commandPrefix = generateCommandHelpPrefix(alias);
 					helpTopic = generateHelpTopic(commandPrefix, shortDescription, currentAliasSb.toString().trim(), permission);
-
-					// Namespaced commands shouldn't have a help topic, we should save the namespaced alias name
-					namespacedCommandNames.add(generateCommandHelpPrefix(alias, command.namespace()));
 				}
 				helpTopicsToAdd.put(commandPrefix, helpTopic);
 			}
@@ -357,11 +350,6 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 
 		// We have to use helpTopics.put (instead of .addTopic) because we're overwriting an existing help topic, not adding a new help topic
 		getHelpMap().putAll(helpTopicsToAdd);
-
-		// We also have to remove help topics for namespaced command names
-		for (String namespacedCommandName : namespacedCommandNames) {
-			getHelpMap().remove(namespacedCommandName);
-		}
 	}
 
 	@Override

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
@@ -276,10 +276,11 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 	}
 
 	void updateHelpForCommands(List<RegisteredCommand> commands) {
-		if (getPaper().isPaperBrigAPI()) return;
 		Map<String, HelpTopic> helpTopicsToAdd = new HashMap<>();
 
 		for (RegisteredCommand command : commands) {
+			if (getPaper().isPaperBrigAPI() && !command.shouldGenerateHelpTopic()) continue;
+
 			// Don't override the plugin help topic
 			String commandPrefix = generateCommandHelpPrefix(command.commandName());
 			

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
@@ -276,6 +276,7 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 	}
 
 	void updateHelpForCommands(List<RegisteredCommand> commands) {
+		if (getPaper().isPaperBrigAPI()) return;
 		Map<String, HelpTopic> helpTopicsToAdd = new HashMap<>();
 
 		for (RegisteredCommand command : commands) {

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/PaperCommandRegistration.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/PaperCommandRegistration.java
@@ -211,9 +211,7 @@ public class PaperCommandRegistration<Source> extends CommandRegistrationStrateg
 				if (helpTopic != null) {
 					description = ((HelpTopic) helpTopic).getShortText();
 				} else {
-					description = command.fullDescription()
-						.orElse(command.shortDescription()
-							.orElse("A command by the " + CommandAPIBukkit.getConfiguration().getPlugin().getName() + " plugin."));
+					description = command.shortDescription().orElse("A command by the " + CommandAPIBukkit.getConfiguration().getPlugin().getName() + " plugin.");
 				}
 				break;
 			}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/PaperCommandRegistration.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/PaperCommandRegistration.java
@@ -91,9 +91,6 @@ public class PaperCommandRegistration<Source> extends CommandRegistrationStrateg
 		LiteralCommandNode<Source> commandNode = asPluginCommand(node.build());
 		LiteralCommandNode<Source> namespacedCommandNode = asPluginCommand(CommandAPIHandler.getInstance().namespaceNode(commandNode, namespace));
 
-		System.out.println(commandNode.getClass().getCanonicalName());
-		System.out.println(namespacedCommandNode.getClass().getCanonicalName());
-
 		// Add to registered command nodes
 		registeredNodes.addChild(commandNode);
 		registeredNodes.addChild(namespacedCommandNode);
@@ -143,13 +140,6 @@ public class PaperCommandRegistration<Source> extends CommandRegistrationStrateg
 			return node;
 		} catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
 			throw new RuntimeException(e);
-		}
-	}
-
-	private void printCommandNode(CommandNode<Source> commandNode, int spaces) {
-		for (CommandNode<Source> child : commandNode.getChildren()) {
-			System.out.println("".repeat(spaces) + child.getName());
-			printCommandNode(child, spaces + 4);
 		}
 	}
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/PaperCommandRegistration.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/PaperCommandRegistration.java
@@ -6,14 +6,20 @@ import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import com.mojang.brigadier.tree.RootCommandNode;
 import io.papermc.paper.plugin.configuration.PluginMeta;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Bukkit;
 import org.bukkit.help.HelpTopic;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
@@ -184,7 +190,7 @@ public class PaperCommandRegistration<Source> extends CommandRegistrationStrateg
 			metaField.set(node, pluginCommandNodeConstructor.newInstance(
 				CommandAPIBukkit.getConfiguration().getPlugin().getPluginMeta(),
 				getDescription(node.getLiteral()),
-				Collections.emptyList()
+				getAliasesForCommand(node.getLiteral())
 			));
 		} catch (NoSuchFieldException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
 			// This doesn't happen
@@ -200,7 +206,7 @@ public class PaperCommandRegistration<Source> extends CommandRegistrationStrateg
 			} else {
 				namespaceStripped = commandName;
 			}
-			if (command.commandName().equals(namespaceStripped)) {
+			if (command.commandName().equals(namespaceStripped) || Arrays.asList(command.aliases()).contains(namespaceStripped)) {
 				Object helpTopic = command.helpTopic().orElse(null);
 				if (helpTopic != null) {
 					description = ((HelpTopic) helpTopic).getShortText();
@@ -213,6 +219,16 @@ public class PaperCommandRegistration<Source> extends CommandRegistrationStrateg
 			}
 		}
 		return description;
+	}
+
+	private List<String> getAliasesForCommand(String commandName) {
+		Set<String> aliases = new HashSet<>();
+		for (RegisteredCommand command : CommandAPI.getRegisteredCommands()) {
+			if (command.commandName().equals(commandName)) {
+				aliases.addAll(Arrays.asList(command.aliases()));
+			}
+		}
+		return new ArrayList<>(aliases);
 	}
 
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/PaperCommandRegistration.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/PaperCommandRegistration.java
@@ -162,6 +162,7 @@ public class PaperCommandRegistration<Source> extends CommandRegistrationStrateg
 			root.addChild(commandNode);
 		}
 		reloadHelpTopics.run();
+		CommandAPIBukkit.get().updateHelpForCommands(CommandAPI.getRegisteredCommands());
 	}
 
 	@SuppressWarnings("unchecked")

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/PaperCommandRegistration.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/PaperCommandRegistration.java
@@ -134,13 +134,12 @@ public class PaperCommandRegistration<Source> extends CommandRegistrationStrateg
 	@SuppressWarnings("unchecked")
 	private LiteralCommandNode<Source> asPluginCommand(LiteralCommandNode<Source> commandNode) {
 		try {
-			LiteralCommandNode<Source> node = (LiteralCommandNode<Source>) pluginCommandNodeConstructor.newInstance(
+			return (LiteralCommandNode<Source>) pluginCommandNodeConstructor.newInstance(
 				commandNode.getLiteral(),
 				CommandAPIBukkit.getConfiguration().getPlugin().getPluginMeta(),
 				commandNode,
 				getDescription(commandNode.getLiteral())
 			);
-			return node;
 		} catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
 			throw new RuntimeException(e);
 		}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/PaperCommandRegistration.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/PaperCommandRegistration.java
@@ -43,8 +43,9 @@ public class PaperCommandRegistration<Source> extends CommandRegistrationStrateg
 		Field dispatcherFieldObject = null;
 
 		try {
-			paperCommandsInstanceObject = Class.forName("io.papermc.paper.command.brigadier.PaperCommands").getField("INSTANCE").get(null);
-			dispatcherFieldObject = Class.forName("io.papermc.paper.command.brigadier.PaperCommands").getDeclaredField("dispatcher");
+			Class<?> paperCommands = Class.forName("io.papermc.paper.command.brigadier.PaperCommands");
+			paperCommandsInstanceObject = paperCommands.getField("INSTANCE").get(null);
+			dispatcherFieldObject = paperCommands.getDeclaredField("dispatcher");
 		} catch (ReflectiveOperationException e) {
 			// Doesn't happen, or rather, shouldn't happen
 		}
@@ -91,14 +92,12 @@ public class PaperCommandRegistration<Source> extends CommandRegistrationStrateg
 
 	@SuppressWarnings("unchecked")
 	public CommandDispatcher<Source> getPaperDispatcher() {
-		CommandDispatcher<?> commandDispatcher;
 		try {
-			commandDispatcher = (CommandDispatcher<?>) dispatcherField.get(paperCommandsInstance);
+			return (CommandDispatcher<Source>) dispatcherField.get(paperCommandsInstance);
 		} catch (IllegalAccessException e) {
 			// This doesn't happen
-			commandDispatcher = null;
+			return null;
 		}
-		return (CommandDispatcher<Source>) commandDispatcher;
 	}
 
 	// Implement CommandRegistrationStrategy methods
@@ -165,7 +164,7 @@ public class PaperCommandRegistration<Source> extends CommandRegistrationStrateg
 	@SuppressWarnings("unchecked")
 	private LiteralCommandNode<Source> asPluginCommand(LiteralCommandNode<Source> commandNode) {
 		try {
-			if (pluginCommandNodeConstructor.getDeclaringClass().getSimpleName().equals("PluginCommandNode")) {
+			if (metaField == null) {
 				return (LiteralCommandNode<Source>) pluginCommandNodeConstructor.newInstance(
 					commandNode.getLiteral(),
 					CommandAPIBukkit.getConfiguration().getPlugin().getPluginMeta(),
@@ -194,7 +193,7 @@ public class PaperCommandRegistration<Source> extends CommandRegistrationStrateg
 	}
 
 	private String getDescription(String commandName) {
-		String namespaceStripped = "";
+		String namespaceStripped;
 		if (commandName.contains(":")) {
 			namespaceStripped = commandName.split(":")[1];
 		} else {
@@ -215,7 +214,7 @@ public class PaperCommandRegistration<Source> extends CommandRegistrationStrateg
 
 	private List<String> getAliasesForCommand(String commandName) {
 		Set<String> aliases = new HashSet<>();
-		String namespaceStripped = "";
+		String namespaceStripped;
 		if (commandName.contains(":")) {
 			namespaceStripped = commandName.split(":")[1];
 		} else {

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/PaperImplementations.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/PaperImplementations.java
@@ -20,6 +20,7 @@ public class PaperImplementations {
 
 	private final boolean isPaperPresent;
 	private final boolean isFoliaPresent;
+	private final boolean isPaperBrigAPI;
 	private final NMS<?> nmsInstance;
 	private final Class<? extends CommandSender> feedbackForwardingCommandSender;
 	private final Class<? extends CommandSender> nullCommandSender;
@@ -54,6 +55,15 @@ public class PaperImplementations {
 		}
 
 		this.nullCommandSender = tempNullCommandSender;
+
+		boolean paperCommandSourceStackPresent;
+		try {
+			Class.forName("io.papermc.paper.command.brigadier.CommandSourceStack");
+			paperCommandSourceStackPresent = true;
+		} catch (ClassNotFoundException e) {
+			paperCommandSourceStackPresent = false;
+		}
+		this.isPaperBrigAPI = paperCommandSourceStackPresent;
 	}
 
 	/**
@@ -109,6 +119,13 @@ public class PaperImplementations {
 	 */
 	public boolean isPaperPresent() {
 		return this.isPaperPresent;
+	}
+
+	/**
+	 * @return whether we're running a Paper server with the Paper Brigadier command API
+	 */
+	public boolean isPaperBrigAPI() {
+		return this.isPaperBrigAPI;
 	}
 	
 	/**

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.5/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R4.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.5/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R4.java
@@ -1071,7 +1071,12 @@ public class NMS_1_20_R4 extends NMS_Common {
 			}
 			return new PaperCommandRegistration<>(
 				() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher(),
-				() -> ((SimpleHelpMap) Bukkit.getServer().getHelpMap()).initializeCommands(),
+				() -> {
+					SimpleHelpMap helpMap = (SimpleHelpMap) Bukkit.getServer().getHelpMap();
+					helpMap.clear();
+					helpMap.initializeGeneralTopics();
+					helpMap.initializeCommands();
+				},
 				node -> bukkitCommandNode_bukkitBrigCommand.isInstance(node.getCommand())
 			);
 		}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.5/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R4.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.5/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R4.java
@@ -1071,12 +1071,7 @@ public class NMS_1_20_R4 extends NMS_Common {
 			}
 			return new PaperCommandRegistration<>(
 				() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher(),
-				() -> {
-					SimpleHelpMap helpMap = (SimpleHelpMap) Bukkit.getServer().getHelpMap();
-					helpMap.clear();
-					helpMap.initializeGeneralTopics();
-					helpMap.initializeCommands();
-				},
+				() -> ((SimpleHelpMap) Bukkit.getServer().getHelpMap()).initializeCommands(),
 				node -> bukkitCommandNode_bukkitBrigCommand.isInstance(node.getCommand())
 			);
 		}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.5/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R4.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.20.5/src/main/java/dev/jorel/commandapi/nms/NMS_1_20_R4.java
@@ -1071,6 +1071,12 @@ public class NMS_1_20_R4 extends NMS_Common {
 			}
 			return new PaperCommandRegistration<>(
 				() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher(),
+				() -> {
+					SimpleHelpMap helpMap = (SimpleHelpMap) Bukkit.getServer().getHelpMap();
+					helpMap.clear();
+					helpMap.initializeGeneralTopics();
+					helpMap.initializeCommands();
+				},
 				node -> bukkitCommandNode_bukkitBrigCommand.isInstance(node.getCommand())
 			);
 		}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_21_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_21_R2.java
@@ -1108,7 +1108,12 @@ public class NMS_1_21_R2 extends NMS_Common {
 			}
 			return new PaperCommandRegistration<>(
 				() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher(),
-				() -> ((SimpleHelpMap) Bukkit.getServer().getHelpMap()).initializeCommands(),
+				() -> {
+					SimpleHelpMap helpMap = (SimpleHelpMap) Bukkit.getServer().getHelpMap();
+					helpMap.clear();
+					helpMap.initializeGeneralTopics();
+					helpMap.initializeCommands();
+				},
 				node -> bukkitCommandNode_bukkitBrigCommand.isInstance(node.getCommand())
 			);
 		}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_21_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_21_R2.java
@@ -1108,12 +1108,7 @@ public class NMS_1_21_R2 extends NMS_Common {
 			}
 			return new PaperCommandRegistration<>(
 				() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher(),
-				() -> {
-					SimpleHelpMap helpMap = (SimpleHelpMap) Bukkit.getServer().getHelpMap();
-					helpMap.clear();
-					helpMap.initializeGeneralTopics();
-					helpMap.initializeCommands();
-				},
+				() -> ((SimpleHelpMap) Bukkit.getServer().getHelpMap()).initializeCommands(),
 				node -> bukkitCommandNode_bukkitBrigCommand.isInstance(node.getCommand())
 			);
 		}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_21_R2.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21.2/src/main/java/dev/jorel/commandapi/nms/NMS_1_21_R2.java
@@ -1108,6 +1108,12 @@ public class NMS_1_21_R2 extends NMS_Common {
 			}
 			return new PaperCommandRegistration<>(
 				() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher(),
+				() -> {
+					SimpleHelpMap helpMap = (SimpleHelpMap) Bukkit.getServer().getHelpMap();
+					helpMap.clear();
+					helpMap.initializeGeneralTopics();
+					helpMap.initializeCommands();
+				},
 				node -> bukkitCommandNode_bukkitBrigCommand.isInstance(node.getCommand())
 			);
 		}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_21_R3.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_21_R3.java
@@ -1154,6 +1154,12 @@ public class NMS_1_21_R3 extends NMS_Common {
 			}
 			return new PaperCommandRegistration<>(
 				() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher(),
+				() -> {
+					SimpleHelpMap helpMap = (SimpleHelpMap) Bukkit.getServer().getHelpMap();
+					helpMap.clear();
+					helpMap.initializeGeneralTopics();
+					helpMap.initializeCommands();
+				},
 				node -> bukkitCommandNode_bukkitBrigCommand.isInstance(node.getCommand())
 			);
 		}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_21_R3.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_21_R3.java
@@ -1154,7 +1154,12 @@ public class NMS_1_21_R3 extends NMS_Common {
 			}
 			return new PaperCommandRegistration<>(
 				() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher(),
-				() -> ((SimpleHelpMap) Bukkit.getServer().getHelpMap()).initializeCommands(),
+				() -> {
+					SimpleHelpMap helpMap = (SimpleHelpMap) Bukkit.getServer().getHelpMap();
+					helpMap.clear();
+					helpMap.initializeGeneralTopics();
+					helpMap.initializeCommands();
+				},
 				node -> bukkitCommandNode_bukkitBrigCommand.isInstance(node.getCommand())
 			);
 		}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_21_R3.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21.4/src/main/java/dev/jorel/commandapi/nms/NMS_1_21_R3.java
@@ -1154,12 +1154,7 @@ public class NMS_1_21_R3 extends NMS_Common {
 			}
 			return new PaperCommandRegistration<>(
 				() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher(),
-				() -> {
-					SimpleHelpMap helpMap = (SimpleHelpMap) Bukkit.getServer().getHelpMap();
-					helpMap.clear();
-					helpMap.initializeGeneralTopics();
-					helpMap.initializeCommands();
-				},
+				() -> ((SimpleHelpMap) Bukkit.getServer().getHelpMap()).initializeCommands(),
 				node -> bukkitCommandNode_bukkitBrigCommand.isInstance(node.getCommand())
 			);
 		}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21/src/main/java/dev/jorel/commandapi/nms/NMS_1_21_R1.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21/src/main/java/dev/jorel/commandapi/nms/NMS_1_21_R1.java
@@ -1069,6 +1069,12 @@ public class NMS_1_21_R1 extends NMS_Common {
 			}
 			return new PaperCommandRegistration<>(
 				() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher(),
+				() -> {
+					SimpleHelpMap helpMap = (SimpleHelpMap) Bukkit.getServer().getHelpMap();
+					helpMap.clear();
+					helpMap.initializeGeneralTopics();
+					helpMap.initializeCommands();
+				},
 				node -> bukkitCommandNode_bukkitBrigCommand.isInstance(node.getCommand())
 			);
 		}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21/src/main/java/dev/jorel/commandapi/nms/NMS_1_21_R1.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21/src/main/java/dev/jorel/commandapi/nms/NMS_1_21_R1.java
@@ -1069,7 +1069,12 @@ public class NMS_1_21_R1 extends NMS_Common {
 			}
 			return new PaperCommandRegistration<>(
 				() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher(),
-				() -> ((SimpleHelpMap) Bukkit.getServer().getHelpMap()).initializeCommands(),
+				() -> {
+					SimpleHelpMap helpMap = (SimpleHelpMap) Bukkit.getServer().getHelpMap();
+					helpMap.clear();
+					helpMap.initializeGeneralTopics();
+					helpMap.initializeCommands();
+				},
 				node -> bukkitCommandNode_bukkitBrigCommand.isInstance(node.getCommand())
 			);
 		}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21/src/main/java/dev/jorel/commandapi/nms/NMS_1_21_R1.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-nms/commandapi-bukkit-1.21/src/main/java/dev/jorel/commandapi/nms/NMS_1_21_R1.java
@@ -1069,12 +1069,7 @@ public class NMS_1_21_R1 extends NMS_Common {
 			}
 			return new PaperCommandRegistration<>(
 				() -> this.<MinecraftServer>getMinecraftServer().getCommands().getDispatcher(),
-				() -> {
-					SimpleHelpMap helpMap = (SimpleHelpMap) Bukkit.getServer().getHelpMap();
-					helpMap.clear();
-					helpMap.initializeGeneralTopics();
-					helpMap.initializeCommands();
-				},
+				() -> ((SimpleHelpMap) Bukkit.getServer().getHelpMap()).initializeCommands(),
 				node -> bukkitCommandNode_bukkitBrigCommand.isInstance(node.getCommand())
 			);
 		}


### PR DESCRIPTION
Fixes #583
Fixes #578 

The behaviour for #578 is unexpected, but corect. After this PR, instead of returning the wrong permission, `getCommandMap("commandname").getPermission()` will return `null`. This is the correct behaviour which can easily be verified if you follow the initialization chain starting here: https://github.com/PaperMC/Paper/blob/09f1f88f58a03f61092f8636ad780d42db87d8d9/paper-server/src/main/java/io/papermc/paper/command/brigadier/PaperBrigadier.java#L49