### PR TITLE
[Feat] AsyncOfflinePlayerArgument

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,10 @@ This is the current roadmap for the CommandAPI (as of 30th April 2024):
             <td valign="top"><b>9.7.1</b></td>
             <td valign="top">???</td>
             <td valign="top">
+				<b>CommandAPI Changes:</b>
+                <ul>
+                    <li>https://github.com/CommandAPI/CommandAPI/pull/633 Adds an <code>AsyncOfflinePlayerArgument</code> to allow asynchronous fetching of an offline player</li>
+                </ul>
                 <b>Bug Fixes:</b>
                 <ul>
                     <li>Fixes <code>PotionEffectArgument.NamespacedKey</code> not having suggestions in some versions</li>

--- a/commandapi-annotations/src/main/java/dev/jorel/commandapi/annotations/Annotations.java
+++ b/commandapi-annotations/src/main/java/dev/jorel/commandapi/annotations/Annotations.java
@@ -50,6 +50,7 @@ import dev.jorel.commandapi.annotations.arguments.AAdventureChatArgument;
 import dev.jorel.commandapi.annotations.arguments.AAdventureChatComponentArgument;
 import dev.jorel.commandapi.annotations.arguments.AAngleArgument;
 import dev.jorel.commandapi.annotations.arguments.AAxisArgument;
+import dev.jorel.commandapi.annotations.arguments.AAsyncOfflinePlayerArgument;
 import dev.jorel.commandapi.annotations.arguments.ABiomeArgument;
 import dev.jorel.commandapi.annotations.arguments.ABlockPredicateArgument;
 import dev.jorel.commandapi.annotations.arguments.ABlockStateArgument;
@@ -107,7 +108,7 @@ public class Annotations extends AbstractProcessor {
 
 	private static final Class<?>[] ARGUMENT_ANNOTATIONS = new Class<?>[] { AAdvancementArgument.class,
 		AAdventureChatArgument.class, AAdventureChatComponentArgument.class, AAngleArgument.class,
-		AAxisArgument.class, ABiomeArgument.class, ABlockPredicateArgument.class, ABlockStateArgument.class,
+		AAxisArgument.class, AAsyncOfflinePlayerArgument.class, ABiomeArgument.class, ABlockPredicateArgument.class, ABlockStateArgument.class,
 		ABooleanArgument.class, AChatArgument.class, AChatColorArgument.class, AChatComponentArgument.class,
 		ADoubleArgument.class, AEnchantmentArgument.class, AEntitySelectorArgument.ManyEntities.class,
 		AEntitySelectorArgument.ManyPlayers.class, AEntitySelectorArgument.OneEntity.class,

--- a/commandapi-annotations/src/main/java/dev/jorel/commandapi/annotations/arguments/AAsyncOfflinePlayerArgument.java
+++ b/commandapi-annotations/src/main/java/dev/jorel/commandapi/annotations/arguments/AAsyncOfflinePlayerArgument.java
@@ -1,0 +1,17 @@
+package dev.jorel.commandapi.annotations.arguments;
+
+import dev.jorel.commandapi.arguments.AsyncOfflinePlayerArgument;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation equivalent of the {@link AsyncOfflinePlayerArgument}
+ */
+@Primitive("java.util.concurrent.CompletableFuture<org.bukkit.OfflinePlayer>")
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.PARAMETER)
+public @interface AAsyncOfflinePlayerArgument {
+}

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/arguments/CommandAPIArgumentType.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/arguments/CommandAPIArgumentType.java
@@ -53,6 +53,12 @@ public enum CommandAPIArgumentType {
 	ANGLE("minecraft:angle"),
 
 	/**
+	 * The AsyncOfflinePlayerArgument
+	 */
+	ASYNC_OFFLINE_PLAYER("api:async_offline_player"),
+
+
+	/**
 	 * The AxisArgument
 	 */
 	AXIS("minecraft:swizzle"),

--- a/commandapi-kotlin/commandapi-bukkit-kotlin/src/main/kotlin/dev/jorel/commandapi/kotlindsl/CommandAPICommandDSL.kt
+++ b/commandapi-kotlin/commandapi-bukkit-kotlin/src/main/kotlin/dev/jorel/commandapi/kotlindsl/CommandAPICommandDSL.kt
@@ -67,6 +67,7 @@ inline fun CommandAPICommand.entitySelectorArgumentOnePlayer(nodeName: String, o
 inline fun CommandAPICommand.entitySelectorArgumentManyPlayers(nodeName: String, allowEmpty: Boolean = true, optional: Boolean = false, block: Argument<*>.() -> Unit = {}): CommandAPICommand = withArguments(EntitySelectorArgument.ManyPlayers(nodeName, allowEmpty).setOptional(optional).apply(block))
 inline fun CommandAPICommand.playerArgument(nodeName: String, optional: Boolean = false, block: Argument<*>.() -> Unit = {}): CommandAPICommand = withArguments(PlayerArgument(nodeName).setOptional(optional).apply(block))
 inline fun CommandAPICommand.offlinePlayerArgument(nodeName: String, optional: Boolean = false, block: Argument<*>.() -> Unit = {}): CommandAPICommand = withArguments(OfflinePlayerArgument(nodeName).setOptional(optional).apply(block))
+inline fun CommandAPICommand.asyncOfflinePlayerArgument(nodeName: String, optional: Boolean = false, block: Argument<*>.() -> Unit = {}): CommandAPICommand = withArguments(AsyncOfflinePlayerArgument(nodeName).setOptional(optional).apply(block))
 inline fun CommandAPICommand.entityTypeArgument(nodeName: String, optional: Boolean = false, block: Argument<*>.() -> Unit = {}): CommandAPICommand = withArguments(EntityTypeArgument(nodeName).setOptional(optional).apply(block))
 
 // Scoreboard arguments

--- a/commandapi-kotlin/commandapi-bukkit-kotlin/src/main/kotlin/dev/jorel/commandapi/kotlindsl/CommandTreeDSL.kt
+++ b/commandapi-kotlin/commandapi-bukkit-kotlin/src/main/kotlin/dev/jorel/commandapi/kotlindsl/CommandTreeDSL.kt
@@ -74,6 +74,7 @@ inline fun CommandTree.entitySelectorArgumentOnePlayer(nodeName: String, optiona
 inline fun CommandTree.entitySelectorArgumentManyPlayers(nodeName: String, allowEmpty: Boolean = true, optional: Boolean = false, block: Argument<*>.() -> Unit = {}): CommandTree = then(EntitySelectorArgument.ManyPlayers(nodeName, allowEmpty).setOptional(optional).apply(block))
 inline fun CommandTree.playerArgument(nodeName: String, optional: Boolean = false, block: Argument<*>.() -> Unit = {}): CommandTree = then(PlayerArgument(nodeName).setOptional(optional).apply(block))
 inline fun CommandTree.offlinePlayerArgument(nodeName: String, optional: Boolean = false, block: Argument<*>.() -> Unit = {}): CommandTree = then(OfflinePlayerArgument(nodeName).setOptional(optional).apply(block))
+inline fun CommandTree.asyncOfflinePlayerArgument(nodeName: String, optional: Boolean = false, block: Argument<*>.() -> Unit = {}): CommandTree = then(AsyncOfflinePlayerArgument(nodeName).setOptional(optional).apply(block))
 inline fun CommandTree.entityTypeArgument(nodeName: String, optional: Boolean = false, block: Argument<*>.() -> Unit = {}): CommandTree = then(EntityTypeArgument(nodeName).setOptional(optional).apply(block))
 
 // Scoreboard arguments
@@ -192,6 +193,7 @@ inline fun Argument<*>.entitySelectorArgumentOnePlayer(nodeName: String, optiona
 inline fun Argument<*>.entitySelectorArgumentManyPlayers(nodeName: String, allowEmpty: Boolean = true, optional: Boolean = false, block: Argument<*>.() -> Unit = {}): Argument<*> = then(EntitySelectorArgument.ManyPlayers(nodeName, allowEmpty).setOptional(optional).apply(block))
 inline fun Argument<*>.playerArgument(nodeName: String, optional: Boolean = false, block: Argument<*>.() -> Unit = {}): Argument<*> = then(PlayerArgument(nodeName).setOptional(optional).apply(block))
 inline fun Argument<*>.offlinePlayerArgument(nodeName: String, optional: Boolean = false, block: Argument<*>.() -> Unit = {}): Argument<*> = then(OfflinePlayerArgument(nodeName).setOptional(optional).apply(block))
+inline fun Argument<*>.asyncOfflinePlayerArgument(nodeName: String, optional: Boolean = false, block: Argument<*>.() -> Unit = {}): Argument<*> = then(AsyncOfflinePlayerArgument(nodeName).setOptional(optional).apply(block))
 inline fun Argument<*>.entityTypeArgument(nodeName: String, optional: Boolean = false, block: Argument<*>.() -> Unit = {}): Argument<*> = then(EntityTypeArgument(nodeName).setOptional(optional).apply(block))
 
 // Scoreboard arguments

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/arguments/AsyncOfflinePlayerArgument.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/arguments/AsyncOfflinePlayerArgument.java
@@ -1,0 +1,49 @@
+package dev.jorel.commandapi.arguments;
+
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import dev.jorel.commandapi.CommandAPIBukkit;
+import dev.jorel.commandapi.executors.CommandArguments;
+import org.bukkit.OfflinePlayer;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * An argument that represents the Bukkit OfflinePlayer object with asynchronous support.
+ *
+ * @since 9.7.1
+ */
+public class AsyncOfflinePlayerArgument extends SafeOverrideableArgument<CompletableFuture<OfflinePlayer>, OfflinePlayer> {
+
+	/**
+	 * A Player argument. Produces a single player, regardless of whether
+	 * <code>@a</code>, <code>@p</code>, <code>@r</code> or <code>@e</code> is used.
+	 *
+	 * @param nodeName the name of the node for this argument
+	 */
+	public AsyncOfflinePlayerArgument(String nodeName) {
+		super(nodeName, CommandAPIBukkit.get()._ArgumentProfile(), OfflinePlayer::getName);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Class<CompletableFuture<OfflinePlayer>> getPrimitiveType() {
+		return (Class<CompletableFuture<OfflinePlayer>>) (Class<?>) CompletableFuture.class;
+	}
+
+	@Override
+	public CommandAPIArgumentType getArgumentType() {
+		return CommandAPIArgumentType.ASYNC_OFFLINE_PLAYER;
+	}
+
+	@Override
+	public <CommandSourceStack> CompletableFuture<OfflinePlayer> parseArgument(CommandContext<CommandSourceStack> cmdCtx, String key, CommandArguments previousArgs) {
+		return CompletableFuture.supplyAsync(() -> {
+			try {
+				return CommandAPIBukkit.<CommandSourceStack>get().getOfflinePlayer(cmdCtx, key);
+			} catch (CommandSyntaxException e) {
+				throw new RuntimeException(e);
+			}
+		});
+	}
+}

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin-common/src/main/java/dev/jorel/commandapi/AdvancedConverter.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin-common/src/main/java/dev/jorel/commandapi/AdvancedConverter.java
@@ -33,6 +33,7 @@ import dev.jorel.commandapi.arguments.AdventureChatComponentArgument;
 import dev.jorel.commandapi.arguments.AngleArgument;
 import dev.jorel.commandapi.arguments.Argument;
 import dev.jorel.commandapi.arguments.AxisArgument;
+import dev.jorel.commandapi.arguments.AsyncOfflinePlayerArgument;
 import dev.jorel.commandapi.arguments.BiomeArgument;
 import dev.jorel.commandapi.arguments.BlockPredicateArgument;
 import dev.jorel.commandapi.arguments.BlockStateArgument;
@@ -234,6 +235,7 @@ class AdvancedConverter {
 			case ADVENTURE_CHAT -> new AdventureChatArgument(nodeName);
 			case ADVENTURE_CHAT_COMPONENT -> new AdventureChatComponentArgument(nodeName);
 			case ANGLE -> new AngleArgument(nodeName);
+			case ASYNC_OFFLINE_PLAYER -> new AsyncOfflinePlayerArgument(nodeName);
 			case AXIS -> new AxisArgument(nodeName);
 			case BIOME -> new BiomeArgument(nodeName);
 			case BLOCKSTATE -> new BlockStateArgument(nodeName);


### PR DESCRIPTION
# Description
This pull request introduces the `AsyncOfflinePlayerArgument`, which extends the `SafeOverrideableArgument` class. The new class wraps the existing `OfflinePlayerArgument` within a `CompletableFuture<OfflinePlayer>`, enabling asynchronous handling of the offline player argument in commands. By using this approach, the logic involving API calls to fetch the offline player will be executed off the main thread, reducing the risk of blocking the server's main thread and improving performance.

## PR Checklist

- [x] Does the pull request have clear and descriptive commit messages that explain the changes made?
- [x] Does the CommandAPI compile successfully? (This will be verified automatically when the pull request is made.)
- [x] Has this been tested in a Minecraft server environment, including compatibility with the latest Minecraft version and Spigot or Paper?
- [ ] Are unit tests required for this feature, and if so, have they been added to the pull request?
- [x] Is documentation included in this pull request, and does it adequately explain the new functionality?

## Documentation
See https://github.com/CommandAPI/docs/pull/1


This PR is in continuation of #632, which I accidentally closed :-)