### PR TITLE
Some updates to networking

### DIFF
--- a/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPIConfig.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/CommandAPIConfig.java
@@ -53,6 +53,8 @@ extends CommandAPIConfig<Impl>
 	boolean usePluginNamespace = false;
 	String namespace = null;
 
+	boolean reportFailedPacketSends;
+
 	/**
 	 * Sets verbose output logging for the CommandAPI if true.
 	 *
@@ -191,4 +193,14 @@ extends CommandAPIConfig<Impl>
 	 */
 	public abstract Impl usePluginNamespace();
 
+	/**
+	 * Sets whether the CommandAPI should throw exceptions if it cannot send a packet.
+	 *
+	 * @param value Whether an exception should be thrown when a packet cannot be sent
+	 * @return this CommandAPIConfig
+	 */
+	public Impl reportFailedPacketSends(boolean value) {
+		this.reportFailedPacketSends = value;
+		return instance();
+	}
 }

--- a/commandapi-core/src/main/java/dev/jorel/commandapi/InternalConfig.java
+++ b/commandapi-core/src/main/java/dev/jorel/commandapi/InternalConfig.java
@@ -58,6 +58,9 @@ public class InternalConfig {
 	// The default command namespace
 	private final String namespace;
 
+	// Whether we should throw an exception when a packet cannot be sent
+	private final boolean reportFailedPacketSends;
+
 	/**
 	 * Creates an {@link InternalConfig} from a {@link CommandAPIConfig}
 	 * 
@@ -74,6 +77,7 @@ public class InternalConfig {
 		this.nbtContainerClass = config.nbtContainerClass;
 		this.nbtContainerConstructor = config.nbtContainerConstructor;
 		this.namespace = config.namespace;
+		this.reportFailedPacketSends = config.reportFailedPacketSends;
 	}
 
 	/**
@@ -153,5 +157,12 @@ public class InternalConfig {
 	 */
 	public String getNamespace() {
 		return namespace;
+	}
+
+	/**
+	 * @return Whether an exception is thrown when a packet cannot be sent
+	 */
+	public boolean shouldReportFailedPacketSends() {
+		return this.reportFailedPacketSends;
 	}
 }

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/CommandAPIBukkit.java
@@ -504,7 +504,10 @@ public abstract class CommandAPIBukkit<Source> implements CommandAPIPlatform<Arg
 
 	@Override
 	public BukkitCommandAPIMessenger setupMessenger() {
-		messenger = new BukkitCommandAPIMessenger(getConfiguration().getPlugin());
+		messenger = new BukkitCommandAPIMessenger(
+			config.getPlugin(),
+			config.shouldReportFailedPacketSends()
+		);
 		return messenger;
 	}
 

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/network/BukkitCommandAPIMessenger.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-core/src/main/java/dev/jorel/commandapi/network/BukkitCommandAPIMessenger.java
@@ -28,10 +28,12 @@ public class BukkitCommandAPIMessenger extends CommandAPIMessenger<Player, Playe
 	/**
 	 * Creates a new {@link BukkitCommandAPIMessenger}.
 	 *
-	 * @param plugin The plugin sending and receiving messages.
+	 * @param plugin            The plugin sending and receiving messages.
+	 * @param reportFailedSends If true, {@link CommandAPIMessenger#sendPacket(Object, CommandAPIPacket)} will throw an exception
+	 *                          if it cannot send the requested packet. Otherwise, if false, that method will fail silently.
 	 */
-	public BukkitCommandAPIMessenger(JavaPlugin plugin) {
-		super(new BukkitPacketHandlerProvider());
+	public BukkitCommandAPIMessenger(JavaPlugin plugin, boolean reportFailedSends) {
+		super(new BukkitPacketHandlerProvider(), reportFailedSends);
 		this.plugin = plugin;
 
 		this.protocolVersionPerPlayer = new HashMap<>();

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-networking-plugin/src/main/java/dev/jorel/commandapi/network/BukkitNetworkingCommandAPIMessenger.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-networking-plugin/src/main/java/dev/jorel/commandapi/network/BukkitNetworkingCommandAPIMessenger.java
@@ -30,7 +30,12 @@ public class BukkitNetworkingCommandAPIMessenger extends CommandAPIMessenger<Pla
 	 * @param plugin The plugin sending and receiving messages.
 	 */
 	public BukkitNetworkingCommandAPIMessenger(CommandAPINetworkingMain plugin) {
-		super(new BukkitNetworkingPacketHandlerProvider(plugin));
+		super(
+			new BukkitNetworkingPacketHandlerProvider(plugin),
+			// Always report failed sends. This isn't expected to do anything
+			//  though since we currently don't send any packets from here.
+			true
+		);
 		this.plugin = plugin;
 
 		this.protocolVersionPerPlayer = new HashMap<>();

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin-common/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin-common/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
@@ -53,7 +53,8 @@ public class CommandAPIMain extends JavaPlugin {
 			.dispatcherFile(fileConfig.getBoolean("create-dispatcher-json") ? new File(getDataFolder(), "command_registration.json") : null)
 			.shouldHookPaperReload(fileConfig.getBoolean("hook-paper-reload"))
 			.skipReloadDatapacks(fileConfig.getBoolean("skip-initial-datapack-reload"))
-			.beLenientForMinorVersions(fileConfig.getBoolean("be-lenient-for-minor-versions"));
+			.beLenientForMinorVersions(fileConfig.getBoolean("be-lenient-for-minor-versions"))
+			.reportFailedPacketSends(fileConfig.getBoolean("report-failed-packet-sends"));
 
 		for (String pluginName : fileConfig.getStringList("skip-sender-proxy")) {
 			if (Bukkit.getPluginManager().getPlugin(pluginName) != null) {

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin-common/src/main/java/dev/jorel/commandapi/config/DefaultBukkitConfig.java
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin-common/src/main/java/dev/jorel/commandapi/config/DefaultBukkitConfig.java
@@ -84,6 +84,7 @@ public class DefaultBukkitConfig extends DefaultConfig {
 		options.put("be-lenient-for-minor-versions", BE_LENIENT_FOR_MINOR_VERSIONS);
 		options.put("hook-paper-reload", SHOULD_HOOK_PAPER_RELOAD);
 		options.put("skip-initial-datapack-reload", SKIP_RELOAD_DATAPACKS);
+		options.put("report-failed-packet-sends", REPORT_FAILED_PACKET_SENDS);
 		options.put("plugins-to-convert", PLUGINS_TO_CONVERT);
 		options.put("other-commands-to-convert", OTHER_COMMANDS_TO_CONVERT);
 		options.put("skip-sender-proxy", SKIP_SENDER_PROXY);

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin-mojang-mapped/src/main/resources/plugin.yml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin-mojang-mapped/src/main/resources/plugin.yml
@@ -9,5 +9,7 @@ authors:
 website: https://www.jorel.dev/CommandAPI/
 softdepend:
   - NBTAPI
+provides:
+  - CommandAPINetworking
 api-version: 1.13
 folia-supported: true

--- a/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/src/main/resources/plugin.yml
+++ b/commandapi-platforms/commandapi-bukkit/commandapi-bukkit-plugin/src/main/resources/plugin.yml
@@ -9,5 +9,7 @@ authors:
 website: https://www.jorel.dev/CommandAPI/
 softdepend:
   - NBTAPI
+provides:
+    - CommandAPINetworking
 api-version: 1.13
 folia-supported: true

--- a/commandapi-platforms/commandapi-velocity/commandapi-velocity-core/src/main/java/dev/jorel/commandapi/CommandAPIVelocity.java
+++ b/commandapi-platforms/commandapi-velocity/commandapi-velocity-core/src/main/java/dev/jorel/commandapi/CommandAPIVelocity.java
@@ -116,8 +116,9 @@ public class CommandAPIVelocity implements CommandAPIPlatform<Argument<?>, Comma
 	@Override
 	public VelocityCommandAPIMessenger setupMessenger() {
 		messenger = new VelocityCommandAPIMessenger(
-			getConfiguration().getPlugin(),
-			getConfiguration().getServer()
+			config.getPlugin(),
+			config.getServer(),
+			config.shouldReportFailedPacketSends()
 		);
 		return messenger;
 	}

--- a/commandapi-platforms/commandapi-velocity/commandapi-velocity-core/src/main/java/dev/jorel/commandapi/network/VelocityCommandAPIMessenger.java
+++ b/commandapi-platforms/commandapi-velocity/commandapi-velocity-core/src/main/java/dev/jorel/commandapi/network/VelocityCommandAPIMessenger.java
@@ -33,11 +33,13 @@ public class VelocityCommandAPIMessenger extends CommandAPIMessenger<ChannelMess
 	/**
 	 * Creates a new {@link VelocityCommandAPIMessenger}.
 	 *
-	 * @param plugin The plugin object (annotated by {@link Plugin}) sending and receiving messages.
-	 * @param proxy  The {@link ProxyServer} the plugin is running on.
+	 * @param plugin            The plugin object (annotated by {@link Plugin}) sending and receiving messages.
+	 * @param proxy             The {@link ProxyServer} the plugin is running on.
+	 * @param reportFailedSends If true, {@link CommandAPIMessenger#sendPacket(Object, CommandAPIPacket)} will throw an exception
+	 *                          if it cannot send the requested packet. Otherwise, if false, that method will fail silently.
 	 */
-	public VelocityCommandAPIMessenger(Object plugin, ProxyServer proxy) {
-		super(new VelocityPacketHandlerProvider());
+	public VelocityCommandAPIMessenger(Object plugin, ProxyServer proxy, boolean reportFailedSends) {
+		super(new VelocityPacketHandlerProvider(), reportFailedSends);
 		this.plugin = plugin;
 		this.proxy = proxy;
 

--- a/commandapi-platforms/commandapi-velocity/commandapi-velocity-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
+++ b/commandapi-platforms/commandapi-velocity/commandapi-velocity-plugin/src/main/java/dev/jorel/commandapi/CommandAPIMain.java
@@ -56,7 +56,8 @@ public class CommandAPIMain {
 			.verboseOutput(configYAML.node("verbose-outputs").getBoolean())
 			.silentLogs(configYAML.node("silent-logs").getBoolean())
 			.missingExecutorImplementationMessage(configYAML.node("messages", "missing-executor-implementation").getString())
-			.dispatcherFile(configYAML.node("create-dispatcher-json").getBoolean() ? new File(dataDirectory.toFile(), "command_registration.json") : null);
+			.dispatcherFile(configYAML.node("create-dispatcher-json").getBoolean() ? new File(dataDirectory.toFile(), "command_registration.json") : null)
+			.reportFailedPacketSends(configYAML.node("report-failed-packet-sends").getBoolean());
 
 		// Load
 		CommandAPI.setLogger(CommandAPILogger.fromJavaLogger(logger));

--- a/commandapi-platforms/commandapi-velocity/commandapi-velocity-plugin/src/main/java/dev/jorel/commandapi/config/DefaultVelocityConfig.java
+++ b/commandapi-platforms/commandapi-velocity/commandapi-velocity-plugin/src/main/java/dev/jorel/commandapi/config/DefaultVelocityConfig.java
@@ -13,6 +13,7 @@ public class DefaultVelocityConfig extends DefaultConfig {
 		options.put("silent-logs", SILENT_LOGS);
 		options.put("messages.missing-executor-implementation", MISSING_EXECUTOR_IMPLEMENTATION);
 		options.put("create-dispatcher-json", CREATE_DISPATCHER_JSON);
+		options.put("report-failed-packet-sends", REPORT_FAILED_PACKET_SENDS);
 
 		Map<String, CommentedSection> sections = new LinkedHashMap<>();
 		sections.put("messages", SECTION_MESSAGE);

--- a/commandapi-plugin/src/main/java/dev/jorel/commandapi/config/DefaultConfig.java
+++ b/commandapi-plugin/src/main/java/dev/jorel/commandapi/config/DefaultConfig.java
@@ -41,6 +41,15 @@ public abstract class DefaultConfig {
 		}, false
 	);
 
+	public static final CommentedConfigOption<Boolean> REPORT_FAILED_PACKET_SENDS = new CommentedConfigOption<>(
+		new String[]{
+			"Report failed packet sends (default: true)",
+			"If \"true\", the CommandAPI will throw an exception if it tries to send a packet but cannot",
+			"(likely due to the receiver not having a new enough CommandAPI version to receive it). If",
+			"\"false\", failed attempts to send a packet will be ignored."
+		}, true
+	);
+
 	public static final CommentedSection SECTION_MESSAGE = new CommentedSection(
 		new String[]{
 			"Messages",


### PR DESCRIPTION
Some updates to the networking logic as suggested by @Timongcraft on Discord.

The `CommandAPI` Bukkit plugin now [provides](https://docs.papermc.io/paper/dev/plugin-yml/#provides) `CommandAPINetworking`. So, if a plugin depends on `CommandAPINetworking`, it will be able to load if `CommandAPINetworking` or `CommandAPI` is present. This makes sense, since `CommandAPI` provides the same networking support that `CommandAPINetworking` does. Provides also allows plugins to load classes from `CommandAPI` like they would from `CommandAPINetworking`, which *technically* doesn't apply here since `CommandAPINetworking` has some unique classes not present in `CommandAPI`. I don't currently expect anyone to load classes from `CommandAPINetworking` though, so this is not a problem right now.

`CommandAPI` Bukkit and `commandapi` Velocity both now have the `report-failed-packet-sends` config option. By default this is `true`, and the CommandAPI will throw a runtime exception if it cannot send a packet because the receiver doesn't have a new enough CommandAPI networking implementation. If set to `false`, these attempts will fail silently. Technically, Bukkit doesn't use this option since it doesn't send any packets right now, but it was easy enough to do this way with the config system, and it might be used eventually. Bukkit Networking doesn't have this option and will always throw since it also doesn't currently send any packets, and I didn't bother adding a config file to that.

Looking for feedback on whether `report-failed-packet-sends: false` should log a warning/error message instead of failing silently. It would be less intrusive than an unhandled exception, and it could still be turned off with `verbose-outputs` or `silent-logs`. (After typing that I kinda convinced myself a warning which you can turn off with `silent-logs` is the best option :P)